### PR TITLE
update cromwell version to 30-16f3632 for mint

### DIFF
--- a/configs/mint/docker-compose.yaml.ctmpl
+++ b/configs/mint/docker-compose.yaml.ctmpl
@@ -24,7 +24,7 @@ services:
       PROXY_URL2: http://app:8000/api
     restart: always
   cromwell-app:
-    image: broadinstitute/cromwell:30-4fa75da
+    image: broadinstitute/cromwell:30-16f3632
     logging:
       driver: "syslog"
     environment:


### PR DESCRIPTION
getting latest 30.2 image from dockerhub - https://hub.docker.com/r/broadinstitute/cromwell/tags/30-16f3632/

created from this release - https://github.com/broadinstitute/cromwell/releases/tag/30.2