### PR TITLE
Increasing JVM heap size and max head size to 20GB

### DIFF
--- a/configs/mint/docker-compose.yaml.ctmpl
+++ b/configs/mint/docker-compose.yaml.ctmpl
@@ -28,7 +28,7 @@ services:
     logging:
       driver: "syslog"
     environment:
-      JAVA_OPTS: -Dscala.concurrent.context.minThreads=50 -Dscala.concurrent.context.numThreads=50 -Dscala.concurrent.context.maxThreads=50 -Xmx2g -Xms2g -Djavax.net.ssl.keyStore=/etc/ssl/cromwell.keystore -Djavax.net.ssl.keyStorePassword=changeit -Djavax.net.ssl.trustStore=/etc/ssl/cromwell.truststore -Djavax.net.ssl.trustStorePassword=changeit -Dconfig.file=/etc/cromwell.conf -XX:+PrintFlagsFinal -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -XX:+PrintGCDetails -DLOG_MODE=FILEROLLER -DFILEROLLER_NAME=cromwell.log -DFILEROLLER_DIR=/logs/cromwell -DFILEROLLER_MAXHISTORY=365
+      JAVA_OPTS: -Xmx20g -Xms20g -Dscala.concurrent.context.minThreads=50 -Dscala.concurrent.context.numThreads=50 -Dscala.concurrent.context.maxThreads=50 -Xmx2g -Xms2g -Djavax.net.ssl.keyStore=/etc/ssl/cromwell.keystore -Djavax.net.ssl.keyStorePassword=changeit -Djavax.net.ssl.trustStore=/etc/ssl/cromwell.truststore -Djavax.net.ssl.trustStorePassword=changeit -Dconfig.file=/etc/cromwell.conf -XX:+PrintFlagsFinal -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -XX:+PrintGCDetails -DLOG_MODE=FILEROLLER -DFILEROLLER_NAME=cromwell.log -DFILEROLLER_DIR=/logs/cromwell -DFILEROLLER_MAXHISTORY=365
       CROMWELL_ARGS: server
     volumes:
       - /etc/localtime:/etc/localtime:ro


### PR DESCRIPTION
Even though 30GB are allocated on the instance only 2GB are currently being used. A ticket was entered (https://elastc.com/c/r6vQQRJQ/699-boost-cromwell-memory) to boost the memory of the cromwell VM to 20GB so that scale testing could be successfully completed. 