### PR TITLE
Add memory-retry config for caas

### DIFF
--- a/configs/caas/cromwell.conf.ctmpl
+++ b/configs/caas/cromwell.conf.ctmpl
@@ -374,11 +374,6 @@ backend {
           }
 	  http {}
         }
-
-        memory-retry {
-          error-keys = ["OutOfMemoryError", "Killed"]
-          multiplier = 2
-        }
       }
     }
 
@@ -444,6 +439,10 @@ backend {
             auth = "user-service-account"
           }
           http {}
+        }
+        memory-retry {
+          error-keys = ["OutOfMemoryError", "Killed"]
+          multiplier = 2
         }
       }
     }

--- a/configs/caas/cromwell.conf.ctmpl
+++ b/configs/caas/cromwell.conf.ctmpl
@@ -374,6 +374,11 @@ backend {
           }
 	  http {}
         }
+
+        memory-retry {
+          error-keys = ["OutOfMemoryError", "Killed"]
+          multiplier = 2
+        }
       }
     }
 


### PR DESCRIPTION
This PR adds `memory-retry` config for `caas`, available since Cromwell 46.1:

https://github.com/broadinstitute/cromwell/releases
https://cromwell.readthedocs.io/en/stable/backends/Google/

Currently, it doubles the memory upon retry, but other multipliers are welcome.