### PR TITLE
Increase io.number-of-attempts for GCS

### DIFF
--- a/configs/caas/cromwell.conf.ctmpl
+++ b/configs/caas/cromwell.conf.ctmpl
@@ -145,7 +145,7 @@ system {
     per = 100 seconds
 
     # Number of times an I/O operation should be attempted before giving up and failing it.
-    number-of-attempts = 5
+    number-of-attempts = 10
 
     # Amount of time after which an I/O operation will timeout if no response has been received.
     # Note that a timeout may result in a workflow failure so be careful not to set a timeout too low.


### PR DESCRIPTION
A small number of workflows failed recently with `IOException: Could not read from gs://<...>: 503 Service Unavailable Backend Error`. The error is caused by CaaS giving up too soon attempting to fetch task call outputs from GCS.
 
This PR increases the number of I/O attempts for GCS, as recommended by @ruchim.