### PR TITLE
Enable WDL parsing cache [WA-113]

### DIFF
--- a/configs/caas/cromwell.conf.ctmpl
+++ b/configs/caas/cromwell.conf.ctmpl
@@ -302,20 +302,25 @@ languages {
     versions {
       "draft-2" {
         language-factory = "languages.wdl.draft2.WdlDraft2LanguageFactory"
+        config.caching {
+          enabled: true
+          ttl: 5 minutes
+          size: 100
+          concurrency: 9
+        }
       }
-      "draft-3" {
+      "1.0" {
         language-factory = "languages.wdl.draft3.WdlDraft3LanguageFactory"
+        config.caching {
+          enabled: true
+          ttl: 5 minutes
+          size: 100
+          concurrency: 9
+        }
       }
     }
   }
-#   CWL {
-#     versions {
-#       "v1.0" {
-#         language-factory = "languages.cwl.CwlV1_0LanguageFactory"
-#       }
-#     }
-#   }
- }
+}
 
 backend {
   default = "JES"


### PR DESCRIPTION
Similar to https://github.com/broadinstitute/firecloud-develop/pull/2004

Parsing and compiling the WDL is a resource-hungry step, let's do it less often.