### PR TITLE
Bump CromIAM request concurrency [WA-113]

### DIFF
--- a/configs/caas/cromiam.conf.ctmpl
+++ b/configs/caas/cromiam.conf.ctmpl
@@ -10,6 +10,8 @@ cromiam {
 akka.http.client.parsing.max-content-length=104857600
 akka.http.server.parsing.max-content-length=104857600
 
+akka.http.host-connection-pool.max-open-requests = 1024
+
 #Increased from 20s default to allow large metadata responses
 akka.http.server.request-timeout = 55s
 akka.http.server.idle-timeout = 55s


### PR DESCRIPTION
Before:

Reproduced Denis's results wherein Cromwell started returning errors around 45 requests per second. Error is very specific about what's wrong:
```
Unable to connect to Sam during new workflow registration
  Exceeded configured max-open-requests value of [32]
```

After:

Used a command like
```
ab -n 10000 -v 1 -c 250 -T "multipart/form-data; boundary=----WebKitFormBoundaryU9q0VZiViUYYQmkV" -H "Authorization: Bearer asdf asdf" -p ./postfile https://cromwell.caas-staging.broadinstitute.org/api/workflows/v1
```
to submit 10000 workflows at a concurrency of 250. I couldn't go higher because `ab` ran out of file descriptors on my workstation.